### PR TITLE
Add email notification on propose

### DIFF
--- a/signalstickers/apps/api/views/contribution_view.py
+++ b/signalstickers/apps/api/views/contribution_view.py
@@ -1,5 +1,6 @@
 from apps.api.serializers import APIPackRequestSerializer, PackRequestSerializer
 from apps.api.services import check_api_key, check_contribution_request
+from apps.core.services import send_email_on_pack_propose
 from apps.stickers.models import Pack, PackStatus
 from django.conf import settings
 from django.core.exceptions import ValidationError
@@ -83,6 +84,7 @@ class ContributionView(APIView):
             except ValidationError as val_err:
                 raise ApiException(str(val_err))
 
+            send_email_on_pack_propose(pack)
             return Response({"success": bool(pack)})
 
         except ApiException as api_err:

--- a/signalstickers/apps/stickers/models/pack.py
+++ b/signalstickers/apps/stickers/models/pack.py
@@ -5,7 +5,7 @@ from apps.stickers.utils import detect_animated_pack, get_pack_from_signal
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
 from django.db import models, transaction
-from django.db.models import Prefetch, prefetch_related_objects
+from django.db.models import Prefetch
 
 from .pack_animated_mode import PackAnimatedMode
 from .pack_status import PackStatus

--- a/signalstickers/signalstickers/settings/dev.py
+++ b/signalstickers/signalstickers/settings/dev.py
@@ -43,3 +43,6 @@ TWITTER_CONF = {
 }
 
 HEADER_IP = "REMOTE_ADDR"
+
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+EMAIL_FROM = "\"Signalstickers\" <Signalstickers@example.com>"

--- a/signalstickers/signalstickers/settings/prod.py.dist
+++ b/signalstickers/signalstickers/settings/prod.py.dist
@@ -62,5 +62,13 @@ SESSION_COOKIE_SECURE = True
 
 HEADER_IP = "HTTP_FOOBAR"
 
+EMAIL_HOST = "FIXME"
+EMAIL_PORT = 465
+EMAIL_HOST_USER = "FIXME"
+EMAIL_FROM = "\"Signalstickers\" <Signalstickers@example.com>"
+EMAIL_HOST_PASSWORD = "FIXME"
+EMAIL_USE_SSL = True
+EMAIL_TIMEOUT = 5
+
 if SECRET_KEY == "FIXME" or DEBUG == True :
     exit("Error: set appropriate prod values in settings/prod.py")


### PR DESCRIPTION
This commit adds a feature to send an email
when a new packs is proposed through the api.

Note: this feature was requested by admins.