### PR TITLE
Add actions to approve and save a pack

### DIFF
--- a/signalstickers/core/models/pack.py
+++ b/signalstickers/core/models/pack.py
@@ -282,3 +282,6 @@ class Pack(models.Model):
             )
 
         return stickers
+
+    def get_model_name(self):
+        return self._meta.model_name

--- a/signalstickers/core/static/core/admin/admin.css
+++ b/signalstickers/core/static/core/admin/admin.css
@@ -73,6 +73,9 @@
     margin-right: 10px;
 }
 
+#save_and_approve_btn{
+    background-color: forestgreen;
+}
 
 @media only screen and (max-width: 930px)  {
     .stats-col{

--- a/signalstickers/core/templates/admin/change_form_pack.html
+++ b/signalstickers/core/templates/admin/change_form_pack.html
@@ -2,7 +2,6 @@
 {% load i18n admin_urls static admin_modify %}
 {% load static %}
 
-
 {% block content %}
 
 {{ block.super }}

--- a/signalstickers/templates/admin/submit_line.html
+++ b/signalstickers/templates/admin/submit_line.html
@@ -1,0 +1,10 @@
+{% extends "admin/submit_line.html" %}
+
+{% block submit-row %}
+{{ block.super }}
+
+{% if original.get_model_name == 'pack'%}
+    <input type="submit" value="Approve and save" name="_approve" id="save_and_approve_btn">
+{% endif %}
+
+{% endblock %}


### PR DESCRIPTION
In the admin, we now have an action to bulk update the Online status of packs
This is also used to approve and save a pack directly from the pack form