### PR TITLE
Add Command to manage and clean unwanted tags

### DIFF
--- a/signalstickers/api/serializers/pack_serializer.py
+++ b/signalstickers/api/serializers/pack_serializer.py
@@ -26,6 +26,10 @@ class PackSerializer(serializers.ModelSerializer):
         )
 
     def to_representation(self, instance):
+        pack_tags_names = [tag.name for tag in instance.tags.all()]
+        # Furry packs should only contain a "furry" tag
+        if "furry" in pack_tags_names:
+            pack_tags_names = ["furry"]
 
         return remove_empty_values(
             {
@@ -33,7 +37,7 @@ class PackSerializer(serializers.ModelSerializer):
                     "id": instance.pack_id,
                     "key": instance.pack_key,
                     "source": instance.source,
-                    "tags": [tag.name for tag in instance.tags.all()],
+                    "tags": pack_tags_names,
                     "nsfw": instance.nsfw,
                     "original": instance.original,
                     "animated": instance.animated,

--- a/signalstickers/api/tests.py
+++ b/signalstickers/api/tests.py
@@ -528,6 +528,36 @@ class PackTestCase(TestCase):
             ],
         )
 
+    def test_pack_cleanup(self, mocked_getpacklib):
+        """Furry packs should not include any other tags than 'Furry'"""
+        mocked_getpacklib.return_value = TestPack(
+            "Pack Furry", "Pack Furry author", b"\x00"
+        )
+
+        # Furry pack with forbidden keywords
+        Pack.objects.new(
+            pack_id="t" * 32,
+            pack_key="t" * 64,
+            status=PackStatus.ONLINE.name,
+            tags=["furry", "sexy", "cute"],
+        )
+
+        response = self.client.get(reverse("packs"))
+        expected_tag = ["furry"]
+        self.assertEqual(
+            response.data,
+            [
+                {
+                    "meta": {"id": "t" * 32, "key": "t" * 64, "tags": expected_tag},
+                    "manifest": {
+                        "title": "Pack Furry",
+                        "author": "Pack Furry author",
+                        "cover": {"id": 42},
+                    },
+                }
+            ],
+        )
+
 
 # pylint: disable=no-member
 class BotPreventionQuestionTestCase(TestCase):

--- a/signalstickers/core/management/commands/clean_packs_tags.py
+++ b/signalstickers/core/management/commands/clean_packs_tags.py
@@ -1,0 +1,31 @@
+from core.models.pack import Pack
+from core.models.pack_status import PackStatus
+from core.models.tag import Tag
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    help = "Look for wrong or malformed tags in packs and correct them."
+
+    def handle(self, *args, **options):
+        # Get all packs except REFUSED ones
+        packs = (
+            Pack.objects.exclude(status=PackStatus.REFUSED.name)
+            .prefetch_related("tags")
+            .order_by("-id")
+        )
+
+        for pack in packs:
+            pack_tags = pack.tags.all()
+
+            for tag in pack_tags:
+                # Malformed tag as "#pastel #unicorn #flowers" should be 3 separated tags
+                if "#" in tag.name:
+                    new_names = tag.name.split("#")
+                    for new_name in new_names:
+                        if new_name:
+                            new_tag, _ = Tag.objects.get_or_create(
+                                name=new_name.strip()
+                            )
+                            pack.tags.add(new_tag)
+                    tag.delete()


### PR DESCRIPTION
Create a new Command to be run every day. The aim is to clean packs tags to be more coherent with the content and to be consistent between each packs. 

-  Fury packs should not contains keywords as "sexy" or "cute"

- Tags formed as "#pastel #unicorn #flowers" should create separate tags instead